### PR TITLE
chore: bump version to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notificationapi-node-server-sdk",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notificationapi-node-server-sdk",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notificationapi-node-server-sdk",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "NotificationAPI server-side library for Node.js",
   "keywords": [
     "notificationapi",


### PR DESCRIPTION
## Changes
- Bumped package version from 2.2.1 to 2.2.2

## Reason for Version Bump
This patch version increment reflects recent changes:
- Security update: Upgraded axios from 0.21.4 to 1.7.9
- Code improvement: Updated test files to use optional chaining for headers

## Type of Change
- [x] Patch version bump (bug fixes, minor updates)
- [ ] Minor version bump (new features, backward compatible)
- [ ] Major version bump (breaking changes)

## Testing
No additional testing required as this is a version bump that follows recent changes that were already tested and merged.