### PR TITLE
Fix import statement for interfaces module to use .js extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notificationapi-node-server-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notificationapi-node-server-sdk",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notificationapi-node-server-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "NotificationAPI server-side library for Node.js",
   "keywords": [
     "notificationapi",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     ".": {
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
+    },
+    "./interfaces": {
+      "import": "./lib/esm/interfaces.js",
+      "require": "./lib/cjs/interfaces.js"
     }
   },
   "files": [

--- a/src/notificationapi.ts
+++ b/src/notificationapi.ts
@@ -9,7 +9,7 @@ import {
   SendRequest,
   SetUserPreferencesRequest,
   User
-} from './interfaces.js';
+} from './interfaces';
 import axios, { AxiosResponse, Method } from 'axios';
 import { createHmac } from 'crypto';
 

--- a/src/notificationapi.ts
+++ b/src/notificationapi.ts
@@ -15,7 +15,7 @@ import { createHmac } from 'crypto';
 
 class NotificationAPIService {
   private USER_AGENT = 'notificationapi-node-server-sdk';
-  private VERSION = '2.2.1';
+  private VERSION = '2.3.1';
 
   clientId: null | string = null;
   clientSecret: null | string = null;

--- a/src/notificationapi.ts
+++ b/src/notificationapi.ts
@@ -9,7 +9,7 @@ import {
   SendRequest,
   SetUserPreferencesRequest,
   User
-} from './interfaces';
+} from './interfaces.js';
 import axios, { AxiosResponse, Method } from 'axios';
 import { createHmac } from 'crypto';
 


### PR DESCRIPTION
Add .js file extension to correctly import the interfaces module and correctly reference the file in the built package.