### PR TITLE
Refactor region configuration and bump version to 2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notificationapi-node-server-sdk",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notificationapi-node-server-sdk",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notificationapi-node-server-sdk",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "NotificationAPI server-side library for Node.js",
   "keywords": [
     "notificationapi",
@@ -22,10 +22,6 @@
     ".": {
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
-    },
-    "./interfaces": {
-      "import": "./lib/esm/interfaces.js",
-      "require": "./lib/cjs/interfaces.js"
     }
   },
   "files": [

--- a/src/__tests__/notificationapi.test.ts
+++ b/src/__tests__/notificationapi.test.ts
@@ -13,9 +13,7 @@ import {
   SendRequest,
   SetUserPreferencesRequest,
   User,
-  US_REGION,
-  EU_REGION,
-  CA_REGION
+  Region
 } from '../interfaces';
 import { createHmac } from 'crypto';
 
@@ -816,31 +814,31 @@ describe('region configuration', () => {
       notificationId: 'test'
     });
     expect(axiosMock.history.post[0].url).toEqual(
-      `${US_REGION}/${clientId}/sender`
+      `${Region.US_REGION}/${clientId}/sender`
     );
   });
 
   test('uses EU region when specified', async () => {
     axiosMock.onAny().reply(200);
-    notificationapi.init(clientId, clientSecret, { baseURL: EU_REGION });
+    notificationapi.init(clientId, clientSecret, { baseURL: Region.EU_REGION });
     await notificationapi.send({
       user: { id: 'test' },
       notificationId: 'test'
     });
     expect(axiosMock.history.post[0].url).toEqual(
-      `${EU_REGION}/${clientId}/sender`
+      `${Region.EU_REGION}/${clientId}/sender`
     );
   });
 
   test('uses CA region when specified', async () => {
     axiosMock.onAny().reply(200);
-    notificationapi.init(clientId, clientSecret, { baseURL: CA_REGION });
+    notificationapi.init(clientId, clientSecret, { baseURL: Region.CA_REGION });
     await notificationapi.send({
       user: { id: 'test' },
       notificationId: 'test'
     });
     expect(axiosMock.history.post[0].url).toEqual(
-      `${CA_REGION}/${clientId}/sender`
+      `${Region.CA_REGION}/${clientId}/sender`
     );
   });
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -100,14 +100,22 @@ export enum Channels {
   PUSH = 'PUSH',
   WEB_PUSH = 'WEB_PUSH'
 }
-/** Region constants for API endpoints */
-export const US_REGION = 'https://api.notificationapi.com';
-export const EU_REGION = 'https://api.eu.notificationapi.com';
-export const CA_REGION = 'https://api.ca.notificationapi.com';
+
+/** Region enum defines the available API endpoints for different geographical regions:
+ * - US_REGION: United States region endpoint (https://api.notificationapi.com)
+ * - EU_REGION: European Union region endpoint (https://api.eu.notificationapi.com)
+ * - CA_REGION: Canada region endpoint (https://api.ca.notificationapi.com)
+ */
+export enum Region {
+  US_REGION = 'https://api.notificationapi.com',
+  EU_REGION = 'https://api.eu.notificationapi.com',
+  CA_REGION = 'https://api.ca.notificationapi.com'
+}
+
 /** To configure the SDK*/
 export interface InitConfiguration {
   /** To update the base url. Optional. Can be a region constant or a custom URL string. */
-  baseURL?: string;
+  baseURL?: string | Region;
 }
 
 export interface PushToken {

--- a/src/notificationapi.ts
+++ b/src/notificationapi.ts
@@ -4,22 +4,24 @@ import {
   InAppNotificationPatchRequest,
   InitConfiguration,
   queryLogsPostBody,
-  US_REGION,
+  Region,
   RetractRequest,
   SendRequest,
   SetUserPreferencesRequest,
   User
-} from './interfaces';
+} from './interfaces.js';
 import axios, { AxiosResponse, Method } from 'axios';
 import { createHmac } from 'crypto';
 
+const DEFAULT_BASE_URL = 'https://api.notificationapi.com';
+
 class NotificationAPIService {
   private USER_AGENT = 'notificationapi-node-server-sdk';
-  private VERSION = '2.3.1';
+  private VERSION = '2.3.2';
 
   clientId: null | string = null;
   clientSecret: null | string = null;
-  baseURL: string = US_REGION;
+  baseURL: string | Region = DEFAULT_BASE_URL;
   /** To configure and initialize the the SDK*/
   init = (
     clientId: string,
@@ -37,7 +39,7 @@ class NotificationAPIService {
     if (config?.baseURL) {
       this.baseURL = config.baseURL;
     } else {
-      this.baseURL = US_REGION;
+      this.baseURL = DEFAULT_BASE_URL;
     }
 
     this.clientId = clientId;


### PR DESCRIPTION
- Convert region constants to an enum (Region)
- Update InitConfiguration to support Region type
- Add default base URL constant
- Update version in package files and SDK
- Modify import statements and tests to use new Region enum