### PR TITLE
Fix: Add backward compatibility for TypeScript 4.3+ and older module resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notificationapi-node-server-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notificationapi-node-server-sdk",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "ISC",
       "dependencies": {
         "@slack/types": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,21 @@
     "url": "https://github.com/notificationapi-com/notificationapi-node-server-sdk/issues"
   },
   "homepage": "https://www.notificationapi.com",
+  "main": "./lib/cjs/index.js",
+  "types": "./lib/cjs/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/cjs/index.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./lib/cjs/index.d.ts"
+      ]
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notificationapi-node-server-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "NotificationAPI server-side library for Node.js",
   "keywords": [
     "notificationapi",


### PR DESCRIPTION
##  Problem:

Customers using TypeScript 4.3.x with `"moduleResolution": "node"` cannot upgrade from SDK v0.14.0 to v2.5.0 due to module resolution issues. If you could test this that would be great. I have tested this with two configs for typescript and a javascript config and all works. When working with an sdk I will npm run build, npm pack then copy the .tgz file to the test setup and run npm i ./name-of-file-here.tgz

### Customer Impact
- **Error**: `Cannot find module 'notificationapi-node-server-sdk' or its corresponding type declarations`
- **Affected**: Projects using TypeScript < 4.7 with classic module resolution
- **Workaround**: Requires changing `moduleResolution` to `node16`/`nodenext` and restructuring import statements across entire codebase

## Trello Ticket:

https://trello.com/c/Ng6FdIum/3525-polyunity-node-update-help

## Root Cause

**The issue**: TypeScript 4.3.x doesn't fully support the `"exports"` field (support was added in TypeScript 4.7), causing module resolution to fail.

## Solution:

Added multi-layered backward compatibility without breaking modern environments:

## How It Works:
- **Modern TypeScript (4.7+)**: Uses `exports` field with conditional exports
- **Older TypeScript (4.3+)**: Falls back to `main` and `types` fields  
- **Intermediate versions**: Can use `typesVersions` mapping

## Testing:

### Test Scenarios
- [x] CommonJS `require()` resolution
- [x] ESM `import` resolution  
- [x] TypeScript declaration file access
- [x] Existing customer upgrade path

## Benefits:
- **Zero breaking changes** - All existing customers continue to work
- **Seamless upgrades** - Customers can upgrade without code changes
- **Future-proof** - Maintains optimal experience for modern environments
- **Broad compatibility** - Works across TypeScript 4.3+ to latest

## Customer Experience:
**Before**: 
```typescript
// Failed with TS 4.3.x + moduleResolution: "node"
import notificationapi from 'notificationapi-node-server-sdk'; //  Module not found
```

**After**:
```typescript  
// Works seamlessly across all supported TypeScript versions
import notificationapi from 'notificationapi-node-server-sdk'; //  Resolves correctly
```